### PR TITLE
Fix getMode (and some minor improvements)

### DIFF
--- a/library/src/fr/ydelouis/widget/AutoFitTextView.java
+++ b/library/src/fr/ydelouis/widget/AutoFitTextView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.text.method.ScrollingMovementMethod;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.widget.TextView;
@@ -37,6 +38,9 @@ public class AutoFitTextView extends TextView
 		maxTextSize = tAttrs.getDimensionPixelSize(R.styleable.AutoFitTextView_maxTextSize, maxTextSize);
 		minTextSize = tAttrs.getDimensionPixelSize(R.styleable.AutoFitTextView_minTextSize, minTextSize);
 		tAttrs.recycle();
+
+        // enable scrolling
+        setMovementMethod(new ScrollingMovementMethod());
 	}
 
 	private void resizeText() {

--- a/library/src/fr/ydelouis/widget/AutoFitTextView.java
+++ b/library/src/fr/ydelouis/widget/AutoFitTextView.java
@@ -18,11 +18,8 @@ public class AutoFitTextView extends TextView
 	
 	private int minTextSize = 1;
 	private int maxTextSize = 1000;
-	
 	private Mode mode = Mode.None;
 	private boolean inComputation;
-	private int widthMeasureSpec;
-	private int heightMeasureSpec;
 
 	public AutoFitTextView(Context context) {
 		super(context);
@@ -47,7 +44,7 @@ public class AutoFitTextView extends TextView
         setHorizontallyScrolling(true);
 	}
 
-	private void resizeText() {
+	private void resizeText(int widthMeasureSpec, int heightMeasureSpec) {
 		if (getWidth() <= 0 || getHeight() <= 0)
 			return;
 		
@@ -85,7 +82,7 @@ public class AutoFitTextView extends TextView
 			return getMeasuredHeight() >= targetHeight;
 	}
 	
-	private Mode getMode(int widthMeasureSpec, int heightMeasureSpec) {
+	private Mode getMode() {
         // MeasureSpec.getMode doesn't work as expected.
         // I thought the mode is MeasureSpec.EXACTLY when the layout
         // is MATCH_PARENT/FILL_PARENT,but actually it's this:
@@ -125,10 +122,8 @@ public class AutoFitTextView extends TextView
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 		if(!inComputation) {
-			this.widthMeasureSpec = widthMeasureSpec;
-			this.heightMeasureSpec = heightMeasureSpec;
-			mode = getMode(widthMeasureSpec, heightMeasureSpec);
-			resizeText();
+			mode = getMode();
+			resizeText(widthMeasureSpec, heightMeasureSpec);
 		}
 	}
 	
@@ -161,13 +156,16 @@ public class AutoFitTextView extends TextView
 
 	@Override
 	protected void onTextChanged(final CharSequence text, final int start, final int before, final int after) {
-		resizeText();
+        // ensure that resizeText is called
+        requestLayout();
 	}
 
 	@Override
 	protected void onSizeChanged(int w, int h, int oldw, int oldh) {
-		if (w != oldw || h != oldh)
-			resizeText();
+		if (w != oldw || h != oldh) {
+            // ensure that resizeText is called
+            requestLayout();
+        }
 	}
 
 	public int getMinTextSize() {
@@ -176,7 +174,8 @@ public class AutoFitTextView extends TextView
 
 	public void setMinTextSize(int minTextSize) {
 		this.minTextSize = minTextSize;
-		resizeText();
+        // ensure that resizeText is called
+        requestLayout();
 	}
 
 	public int getMaxTextSize() {
@@ -185,6 +184,7 @@ public class AutoFitTextView extends TextView
 
 	public void setMaxTextSize(int maxTextSize) {
 		this.maxTextSize = maxTextSize;
-		resizeText();
+        // ensure that resizeText is called
+        requestLayout();
 	}
 }

--- a/library/src/fr/ydelouis/widget/AutoFitTextView.java
+++ b/library/src/fr/ydelouis/widget/AutoFitTextView.java
@@ -57,7 +57,7 @@ public class AutoFitTextView extends TextView
 		inComputation = true;
 		float higherSize = maxTextSize;
 		float lowerSize = minTextSize;
-		float textSize = getTextSize();
+		float textSize;
 		while(higherSize - lowerSize > THRESHOLD) {
 			textSize = (higherSize + lowerSize) / 2;
 			if (isTooBig(textSize, targetWidth, targetHeight)) {


### PR DESCRIPTION
I stumbled upon your repo when I read this [stackoverflow article](http://stackoverflow.com/questions/2617266/how-to-adjust-text-font-size-to-fit-textview).

Concerning the main (second) commit:
I noticed that setting the _layout_width_ and _layout_height_ didn't always give me the layout I expected. The comments in the _getMode()_ method explain exactly why I switched from your initial _MeasureSpec_ to reading the _LayoutParams_.
